### PR TITLE
Filter out primary::SchemaMigration class from AR descendants

### DIFF
--- a/lib/seed_dump/environment.rb
+++ b/lib/seed_dump/environment.rb
@@ -76,6 +76,7 @@ class SeedDump
       #   - Models whose corresponding database tables are empty.
       filtered_models = models.select do |model|
                           !ACTIVE_RECORD_INTERNAL_MODELS.include?(model.to_s) && \
+                          model.name != "primary::SchemaMigration" && \
                           model.table_exists? && \
                           model.exists?
                         end


### PR DESCRIPTION
This is a fix for your PR ( https://github.com/rroblak/seed_dump/pull/144 ). 

The errors in the specs appear to result from an additional class being returned by `ActiveRecord::Base.descendants`. 

Once it's filtered out, all tests pass and everything appears to work in both Rails 6 and 4/5.